### PR TITLE
test: remove spurious test instruction from ASDF

### DIFF
--- a/type-templates.asd
+++ b/type-templates.asd
@@ -15,5 +15,4 @@
                (:file "documentation"))
   :depends-on (:documentation-utils
                :alexandria
-               :form-fiddle)
-  :in-order-to ((asdf:test-op (asdf:test-op :type-templates-test))))
+               :form-fiddle))


### PR DESCRIPTION
Make `(asdf:test-system "type-templates")` pass.

Fixes #1